### PR TITLE
Fix bug in IE8 when loading empty stylesheets

### DIFF
--- a/selectivizr2.js
+++ b/selectivizr2.js
@@ -384,7 +384,7 @@
 	function loadStyleSheet( url ) {
 		xhr.open("GET", url, false);
 		xhr.send();
-		return (xhr.status==200) ? xhr.responseText : EMPTY_STRING;
+		return (xhr.status==200) ? (xhr.responseText != null ? xhr.responseText : EMPTY_STRING) : EMPTY_STRING;
 	}
 
 	// --[ resolveUrl() ]---------------------------------------------------


### PR DESCRIPTION
Loading an empty stylesheet might result in the `xhr.responseText` being `null`. Rest of the code expect an EMPTY_STRING. Returning null will cause a JavaScript error. I admit that it is weird to serve an empty style sheet, but it should not break Selectivizr.
